### PR TITLE
Fix broken player if mounted path had a trailing slash.

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -82,7 +82,7 @@ pub fn get_api_handler(collection: Arc<Collection>) -> Mount {
 }
 
 fn path_from_request(request: &Request) -> Result<PathBuf> {
-	let path_string = request.url.path().join("\\");
+	let path_string = request.url.path().join("/");
 	let decoded_path = percent_decode(path_string.as_bytes()).decode_utf8()?;
 	Ok(PathBuf::from(decoded_path.deref()))
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -82,7 +82,7 @@ pub fn get_api_handler(collection: Arc<Collection>) -> Mount {
 }
 
 fn path_from_request(request: &Request) -> Result<PathBuf> {
-	let path_string = request.url.path().join("/");
+	let path_string = request.url.path().join(&::std::path::MAIN_SEPARATOR.to_string());
 	let decoded_path = percent_decode(path_string.as_bytes()).decode_utf8()?;
 	Ok(PathBuf::from(decoded_path.deref()))
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,12 +193,10 @@ impl Config {
 
 fn clean_path_string(path_string: &str) -> path::PathBuf {
 	let separator_regex = regex::Regex::new(r"\\|/").unwrap();
-	let trailing_regex = regex::Regex::new(r"(/)+$").unwrap();
 	let mut correct_separator = String::new();
 	correct_separator.push(path::MAIN_SEPARATOR);
 	let path_string = separator_regex.replace_all(path_string, correct_separator.as_str());
-	let path_string = trailing_regex.replace_all(&path_string, "");
-	path::PathBuf::from(path_string)
+	path::Path::new(&path_string).iter().collect()
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -193,9 +193,11 @@ impl Config {
 
 fn clean_path_string(path_string: &str) -> path::PathBuf {
 	let separator_regex = regex::Regex::new(r"\\|/").unwrap();
+	let trailing_regex = regex::Regex::new(r"(/)+$").unwrap();
 	let mut correct_separator = String::new();
 	correct_separator.push(path::MAIN_SEPARATOR);
 	let path_string = separator_regex.replace_all(path_string, correct_separator.as_str());
+	let path_string = trailing_regex.replace_all(&path_string, "");
 	path::PathBuf::from(path_string)
 }
 
@@ -213,10 +215,14 @@ fn test_clean_path_string() {
 		assert_eq!(correct_path, clean_path_string(r#"C:/some/path"#));
 		assert_eq!(correct_path, clean_path_string(r#"C:\some\path"#));
 		assert_eq!(correct_path, clean_path_string(r#"C:\some\path\"#));
+		assert_eq!(correct_path, clean_path_string(r#"C:\some\path\\\\"#));
+		assert_eq!(correct_path, clean_path_string(r#"C:\some/path//"#));
 	} else {
 		assert_eq!(correct_path, clean_path_string(r#"/usr/some/path"#));
 		assert_eq!(correct_path, clean_path_string(r#"/usr\some\path"#));
 		assert_eq!(correct_path, clean_path_string(r#"/usr\some\path\"#));
+		assert_eq!(correct_path, clean_path_string(r#"/usr\some\path\\\\"#));
+		assert_eq!(correct_path, clean_path_string(r#"/usr\some/path//"#));
 	}
 
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,8 @@ use errors::*;
 pub fn get_config_root() -> Result<PathBuf> {
 	if let Ok(mut root) = data_root(AppDataType::SharedConfig) {
 		root.push("Polaris");
-		fs::create_dir_all(&root)?;
+		fs::create_dir_all(&root)
+			.chain_err(|| format!("opening shared config: {}", root.display()))?;
 		return Ok(root);
 	}
 	bail!("Could not retrieve config directory root");
@@ -16,7 +17,8 @@ pub fn get_config_root() -> Result<PathBuf> {
 pub fn get_cache_root() -> Result<PathBuf> {
 	if let Ok(mut root) = data_root(AppDataType::SharedData) {
 		root.push("Polaris");
-		fs::create_dir_all(&root)?;
+		fs::create_dir_all(&root)
+			.chain_err(|| format!("opening shared data: {}", root.display()))?;
 		return Ok(root);
 	}
 	bail!("Could not retrieve cache directory root");


### PR DESCRIPTION
The query on browse_songs wasn't returning any results as in the database they 
were save without the trailing slash.

Add two complementary output messages in case of errors trying to
create SharedData and SharedConfig where on Linux XDG defaults to
readonly system wide paths based on XDG_CONFIG_DIRS and XDG_DATA_DIRS
default values from spec (/etc/xdg and /usr/share for example).

And a minor change in the api to use forward slash.