### PR TITLE
Fix logging in docker.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,15 +124,15 @@ fn daemonize(options: &getopts::Matches) -> Result<()> {
 #[cfg(unix)]
 fn init_log(log_level: LevelFilter, options: &getopts::Matches) -> Result<()> {
 	if options.opt_present("f") {
-		if let Err(_) = TermLogger::init(log_level, LOG_CONFIG) {
-            if let Err(e) = SimpleLogger::init(log_level, LOG_CONFIG) {
-                bail!("Error starting terminal logger: {}", e);
-            };
-		};
-	} else {
-		if let Err(e) = SimpleLogger::init(log_level, LOG_CONFIG) {
-			bail!("Error starting simple logger: {}", e);
+		if let Err(e) = TermLogger::init(log_level, LOG_CONFIG) {
+			println!("Error starting terminal logger: {}", e);
+		} else {
+			return Ok(());
 		}
+	}
+
+	if let Err(e) = SimpleLogger::init(log_level, LOG_CONFIG) {
+		bail!("Error starting simple logger: {}", e);
 	}
 	Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,8 +124,10 @@ fn daemonize(options: &getopts::Matches) -> Result<()> {
 #[cfg(unix)]
 fn init_log(log_level: LevelFilter, options: &getopts::Matches) -> Result<()> {
 	if options.opt_present("f") {
-		if let Err(e) = TermLogger::init(log_level, LOG_CONFIG) {
-			bail!("Error starting terminal logger: {}", e);
+		if let Err(_) = TermLogger::init(log_level, LOG_CONFIG) {
+            if let Err(e) = SimpleLogger::init(log_level, LOG_CONFIG) {
+                bail!("Error starting terminal logger: {}", e);
+            };
 		};
 	} else {
 		if let Err(e) = SimpleLogger::init(log_level, LOG_CONFIG) {


### PR DESCRIPTION
Docker by default doesn't have a TTY. The TermLogger doesn't work in that case.
If the TermLogger can't be initiated, try the SimpleLogger.
See https://github.com/Drakulix/simplelog.rs/issues/30 for a similar case.