### PR TITLE
Disable optimizations for some build-time crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,6 @@ unix-daemonize = "0.1.2"
 
 [dev-dependencies]
 percent-encoding = "2.1"
+
+[profile.release.build-override]
+opt-level = 0


### PR DESCRIPTION
This brings down the build time from 4m 21s to 3m 4s.

It's not ideal because some of the crates are now built twice (if they're needed at both build- and run-time). I tried to manually specify the build-time only crates, but I must have missed a couple, because the build still took longer (3m 16s). For the record, my list was:

- `proc-macro2`
- `proc-macro-hack`
- `quote`
- `syn`
- `serde_derive`
- `rocket_codegen`
- `synstructure`
- `derive_builder`
- `derive_builder_core`
- `pear_codegen`
- `num-derive`
- `failure_derive`
- `diesel_derives`
- `migrations_macros`
- `thiserror-impl`
- `function_name-proc-macro`