### PR TITLE
Drop function_name dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,24 +706,6 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "function_name"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "function_name-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "function_name-proc-macro"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "futures"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,7 +1527,6 @@ dependencies = [
  "diesel_migrations 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flame 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flamer 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "function_name 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "id3 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1583,14 +1564,6 @@ dependencies = [
 name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "proc-macro-crate"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "proc-macro-hack"
@@ -2882,8 +2855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum function_name 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88b2afa9b514dc3a75af6cf24d1914e1c7eb6f1b86de849147563548d5c0a0cd"
-"checksum function_name-proc-macro 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6790a8d356d2f65d7972181e866b92a50a87c27d6a48cbe9dbb8be13ca784c7d"
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
@@ -2972,7 +2943,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum png 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef859a23054bbfee7811284275ae522f0434a3c8e7f4b74bd4a35ae7e1c4a283"
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
-"checksum proc-macro-crate 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e10d4b51f154c8a7fb96fd6dad097cb74b863943ec010ac94b9fd1be8861fe1e"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ diesel = { version = "1.4", features = ["sqlite", "r2d2"] }
 diesel_migrations = { version = "1.4", features = ["sqlite"] }
 flame = { version = "0.2.2", optional = true }
 flamer = { version = "0.4", optional = true }
-function_name = "0.2.0"
 getopts = "0.2.15"
 http = "0.2"
 id3 = "0.4"

--- a/src/service/test.rs
+++ b/src/service/test.rs
@@ -1,5 +1,4 @@
 use cookie::Cookie;
-use function_name::named;
 use http::header::*;
 use http::{HeaderMap, HeaderValue, Response, StatusCode};
 use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
@@ -15,6 +14,7 @@ use crate::{config, ddns, index, vfs};
 #[cfg(feature = "service-rocket")]
 pub use crate::service::rocket::test::ServiceType;
 
+const TEST_DB_PREFIX: &str = "service-test-";
 const TEST_USERNAME: &str = "test_user";
 const TEST_PASSWORD: &str = "test_password";
 const TEST_MOUNT_NAME: &str = "collection";
@@ -80,40 +80,35 @@ pub trait TestService {
 	}
 }
 
-#[named]
 #[test]
 fn test_service_index() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.get("/");
 }
 
-#[named]
 #[test]
 fn test_service_swagger_index() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	assert!(service.get("/swagger").status() == StatusCode::OK);
 }
 
-#[named]
 #[test]
 fn test_service_swagger_index_with_trailing_slash() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	assert!(service.get("/swagger/").status() == StatusCode::OK);
 }
 
-#[named]
 #[test]
 fn test_service_version() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	let response = service.get_json::<dto::Version>("/api/version");
 	let version = response.body();
 	assert_eq!(version, &dto::Version { major: 4, minor: 0 });
 }
 
-#[named]
 #[test]
 fn test_service_initial_setup() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	{
 		let response = service.get_json::<dto::InitialSetup>("/api/initial_setup");
 		let initial_setup = response.body();
@@ -137,10 +132,9 @@ fn test_service_initial_setup() {
 	}
 }
 
-#[named]
 #[test]
 fn test_service_settings() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 
 	assert!(service.get("/api/settings").status() == StatusCode::UNAUTHORIZED);
@@ -226,16 +220,14 @@ fn test_service_settings() {
 	assert_eq!(received, &configuration);
 }
 
-#[named]
 #[test]
 fn test_service_preferences() {
 	// TODO
 }
 
-#[named]
 #[test]
 fn test_service_trigger_index() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 	service.login();
 
@@ -250,10 +242,9 @@ fn test_service_trigger_index() {
 	assert_eq!(entries.len(), 2);
 }
 
-#[named]
 #[test]
 fn test_service_auth() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 
 	{
@@ -289,10 +280,9 @@ fn test_service_auth() {
 	}
 }
 
-#[named]
 #[test]
 fn test_service_browse() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 	service.login();
 	service.index();
@@ -315,10 +305,9 @@ fn test_service_browse() {
 	assert_eq!(entries.len(), 5);
 }
 
-#[named]
 #[test]
 fn test_service_flatten() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 	service.login();
 	service.index();
@@ -332,10 +321,9 @@ fn test_service_flatten() {
 	assert_eq!(entries.len(), 12);
 }
 
-#[named]
 #[test]
 fn test_service_random() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 	service.login();
 	service.index();
@@ -345,10 +333,9 @@ fn test_service_random() {
 	assert_eq!(entries.len(), 2);
 }
 
-#[named]
 #[test]
 fn test_service_recent() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 	service.login();
 	service.index();
@@ -358,10 +345,9 @@ fn test_service_recent() {
 	assert_eq!(entries.len(), 2);
 }
 
-#[named]
 #[test]
 fn test_service_search() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 	service.login();
 	service.index();
@@ -375,10 +361,9 @@ fn test_service_search() {
 	}
 }
 
-#[named]
 #[test]
 fn test_service_serve() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 	service.login();
 	service.index();
@@ -407,10 +392,9 @@ fn test_service_serve() {
 	}
 }
 
-#[named]
 #[test]
 fn test_service_playlists() {
-	let mut service = ServiceType::new(function_name!());
+	let mut service = ServiceType::new(&format!("{}{}", TEST_DB_PREFIX, line!()));
 	service.complete_initial_setup();
 	service.login();
 	service.index();


### PR DESCRIPTION
I think this looks a bit worse than using the test name directly. I suppose I could make a macro that expands to that..