### PR TITLE
Support UNIX platforms that aren't Linux

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,13 +3,13 @@ use app_dirs::{app_root, AppDataType, AppInfo};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(target_family = "windows")]
 const APP_INFO: AppInfo = AppInfo {
 	name: "Polaris",
 	author: "Permafrost",
 };
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_family = "windows"))]
 const APP_INFO: AppInfo = AppInfo {
 	name: "polaris",
 	author: "permafrost",


### PR DESCRIPTION
This PR makes a small change so that Polaris works properly on UNIX platforms that aren't Linux. In my particular case this is [FreeBSD](https://www.freebsd.org/). With the old code it would select the `#[cfg(not(target_os = "linux"))]` version and then fail to find any of the web resources and just give a 404 to all requests.

The change makes it so that Windows is the only platform that gets the uppercase data dir. With this change in place Polaris runs fine on FreeBSD.