### PR TITLE
Add a link to Polarios in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Password: `demo_password`
 - Support for `flac`, `mp3`, `mp4`, `mpc`, `ogg`, `opus`, `ape`, `wav` and `aiff` files
 - Easy to setup and administer, no configuration files needed
 - Dark mode and customizable color themes
-- [Last.fm](https://www.last.fm) scrobbling
 - Listen to your music on the go:
   - Polaris Android ([Google Play Store](https://play.google.com/store/apps/details?id=agersant.polaris) · [F-Droid](https://f-droid.org/packages/agersant.polaris/) · [Repository](https://github.com/agersant/polaris-android))
   - Polarios ([App Store](https://apps.apple.com/app/polarios/id1662366309) · [Repository](https://gitlab.com/elise/Polarios))
+- [Last.fm](https://www.last.fm) scrobbling
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Password: `demo_password`
 - Support for `flac`, `mp3`, `mp4`, `mpc`, `ogg`, `opus`, `ape`, `wav` and `aiff` files
 - Easy to setup and administer, no configuration files needed
 - Dark mode and customizable color themes
-- Listen to your music on the go with [Polaris Android](https://github.com/agersant/polaris-android)
+- Listen to your music on the go with [Polaris Android](https://github.com/agersant/polaris-android) or [Polarios](https://gitlab.com/elise/Polarios) (unofficial client for iOS, [App Store](https://apps.apple.com/de/app/polarios/id1662366309))
 - [Last.fm](https://www.last.fm) scrobbling
 
 ## Tutorials

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Check out the demo over at https://demo.polaris.stream, featuring a selection of
 Username: `demo_user`  
 Password: `demo_password`
 
-## Features
+## Features!
 
 ![Polaris Web UI](res/readme/web_ui.png?raw=true "Polaris Web UI")
 
@@ -21,8 +21,10 @@ Password: `demo_password`
 - Support for `flac`, `mp3`, `mp4`, `mpc`, `ogg`, `opus`, `ape`, `wav` and `aiff` files
 - Easy to setup and administer, no configuration files needed
 - Dark mode and customizable color themes
-- Listen to your music on the go with [Polaris Android](https://github.com/agersant/polaris-android) or [Polarios](https://gitlab.com/elise/Polarios) (unofficial client for iOS, [App Store](https://apps.apple.com/de/app/polarios/id1662366309))
 - [Last.fm](https://www.last.fm) scrobbling
+- Listen to your music on the go:
+  - Polaris Android ([Google Play Store](https://play.google.com/store/apps/details?id=agersant.polaris) · [F-Droid](https://f-droid.org/packages/agersant.polaris/) · [Repository](https://github.com/agersant/polaris-android))
+  - Polarios ([App Store](https://apps.apple.com/app/polarios/id1662366309) · [Repository](https://gitlab.com/elise/Polarios))
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Check out the demo over at https://demo.polaris.stream, featuring a selection of
 Username: `demo_user`  
 Password: `demo_password`
 
-## Features!
+## Features
 
 ![Polaris Web UI](res/readme/web_ui.png?raw=true "Polaris Web UI")
 


### PR DESCRIPTION
Hi! 

I made a native iOS client using SwiftUI for Polaris over the last week and it got approved to the App Store today.
This merge request adds a link to it in the feature list where the Polaris Android client is mentioned.
I am not an iOS developer, nor a front-end developer, so it's not perfect but it works.

Meow,
Elise