### PR TITLE
Thumbnails for opus/ogg

### DIFF
--- a/src/app/index/metadata.rs
+++ b/src/app/index/metadata.rs
@@ -255,6 +255,7 @@ fn read_vorbis(path: &Path) -> Result<SongTags, Error> {
 				"COMPOSER" => tags.composer = Some(value),
 				"GENRE" => tags.genre = Some(value),
 				"PUBLISHER" => tags.label = Some(value),
+				"METADATA_BLOCK_PICTURE" => tags.has_artwork = true,
 				_ => (),
 			}
 		}
@@ -296,6 +297,7 @@ fn read_opus(path: &Path) -> Result<SongTags, Error> {
 				"COMPOSER" => tags.composer = Some(value),
 				"GENRE" => tags.genre = Some(value),
 				"PUBLISHER" => tags.label = Some(value),
+				"METADATA_BLOCK_PICTURE" => tags.has_artwork = true,
 				_ => (),
 			}
 		}

--- a/src/app/thumbnail.rs
+++ b/src/app/thumbnail.rs
@@ -206,12 +206,12 @@ fn read_mp4(path: &Path) -> Result<DynamicImage, Error> {
 		.and_then(|d| image::load_from_memory(d.data).map_err(|e| Error::Image(path.to_owned(), e)))
 }
 
-fn read_vorbis(_: &Path) -> Result<DynamicImage, Error> {
-	Err(Error::UnsupportedFormat("vorbis"))
+fn read_vorbis(path: &Path) -> Result<DynamicImage, Error> {
+	read_flac(path)
 }
 
-fn read_opus(_: &Path) -> Result<DynamicImage, Error> {
-	Err(Error::UnsupportedFormat("opus"))
+fn read_opus(path: &Path) -> Result<DynamicImage, Error> {
+	read_flac(path)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
opus and ogg seem to work fine using the flac thumbnail handler so I added that

before
![Screenshot from 2024-05-02 21-39-03](https://github.com/agersant/polaris/assets/58538423/b0e8af4a-1d7e-4b41-9232-12e1458508cd)
after
![Screenshot from 2024-05-02 21-38-51](https://github.com/agersant/polaris/assets/58538423/ace26ca5-96db-4db5-b164-f6c031814d66)
