### PR TITLE
Add support for m4b format

### DIFF
--- a/src/app/index/metadata.rs
+++ b/src/app/index/metadata.rs
@@ -94,6 +94,7 @@ pub fn read(path: &Path) -> Option<SongTags> {
 		Some(AudioFormat::OGG) => read_vorbis(path),
 		Some(AudioFormat::OPUS) => read_opus(path),
 		Some(AudioFormat::WAVE) => read_wave(path),
+		Some(AudioFormat::M4B) => read_mp4(path), // Metadata of m4b same as mp4
 		None => return None,
 	};
 	match data {

--- a/src/app/index/metadata.rs
+++ b/src/app/index/metadata.rs
@@ -86,15 +86,13 @@ impl From<id3::Tag> for SongTags {
 pub fn read(path: &Path) -> Option<SongTags> {
 	let data = match utils::get_audio_format(path) {
 		Some(AudioFormat::AIFF) => read_aiff(path),
-		Some(AudioFormat::APE) => read_ape(path),
 		Some(AudioFormat::FLAC) => read_flac(path),
 		Some(AudioFormat::MP3) => read_mp3(path),
-		Some(AudioFormat::MP4) => read_mp4(path),
-		Some(AudioFormat::MPC) => read_ape(path),
 		Some(AudioFormat::OGG) => read_vorbis(path),
 		Some(AudioFormat::OPUS) => read_opus(path),
 		Some(AudioFormat::WAVE) => read_wave(path),
-		Some(AudioFormat::M4B) => read_mp4(path), // Metadata of m4b same as mp4
+		Some(AudioFormat::APE) | Some(AudioFormat::MPC) => read_ape(path),
+		Some(AudioFormat::MP4) | Some(AudioFormat::M4B) => read_mp4(path),
 		None => return None,
 	};
 	match data {

--- a/src/app/thumbnail.rs
+++ b/src/app/thumbnail.rs
@@ -149,15 +149,13 @@ fn generate_thumbnail(image_path: &Path, options: &Options) -> Result<DynamicIma
 fn read(image_path: &Path) -> Result<DynamicImage, Error> {
 	match get_audio_format(image_path) {
 		Some(AudioFormat::AIFF) => read_aiff(image_path),
-		Some(AudioFormat::APE) => read_ape(image_path),
 		Some(AudioFormat::FLAC) => read_flac(image_path),
 		Some(AudioFormat::MP3) => read_mp3(image_path),
-		Some(AudioFormat::MP4) => read_mp4(image_path),
-		Some(AudioFormat::MPC) => read_ape(image_path),
 		Some(AudioFormat::OGG) => read_vorbis(image_path),
 		Some(AudioFormat::OPUS) => read_opus(image_path),
 		Some(AudioFormat::WAVE) => read_wave(image_path),
-		Some(AudioFormat::M4B) => read_mp4(image_path), // Metadata of m4b same as mp4
+		Some(AudioFormat::APE) | Some(AudioFormat::MPC) => read_ape(image_path),
+		Some(AudioFormat::MP4) | Some(AudioFormat::M4B) => read_mp4(image_path),
 		None => image::open(image_path).map_err(|e| Error::Image(image_path.to_owned(), e)),
 	}
 }

--- a/src/app/thumbnail.rs
+++ b/src/app/thumbnail.rs
@@ -157,6 +157,7 @@ fn read(image_path: &Path) -> Result<DynamicImage, Error> {
 		Some(AudioFormat::OGG) => read_vorbis(image_path),
 		Some(AudioFormat::OPUS) => read_opus(image_path),
 		Some(AudioFormat::WAVE) => read_wave(image_path),
+		Some(AudioFormat::M4B) => read_mp4(image_path), // Metadata of m4b same as mp4
 		None => image::open(image_path).map_err(|e| Error::Image(image_path.to_owned(), e)),
 	}
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,6 +24,7 @@ pub enum AudioFormat {
 	OGG,
 	OPUS,
 	WAVE,
+	M4B,
 }
 
 pub fn get_audio_format(path: &Path) -> Option<AudioFormat> {
@@ -46,6 +47,7 @@ pub fn get_audio_format(path: &Path) -> Option<AudioFormat> {
 		"ogg" => Some(AudioFormat::OGG),
 		"opus" => Some(AudioFormat::OPUS),
 		"wav" => Some(AudioFormat::WAVE),
+		"m4b" => Some(AudioFormat::M4B),
 		_ => None,
 	}
 }


### PR DESCRIPTION
Currently, `polaris` does not recognize audiobook files in m4b extension. The format could be added easily though, as M4B is essentially an MP4 audio file. 