### PR TITLE
Add reference to the 'Polarity' project to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Password: `demo_password`
 - 📱 Listen to your music on the go:
   - Polaris Android ([Google Play Store](https://play.google.com/store/apps/details?id=agersant.polaris) · [F-Droid](https://f-droid.org/packages/agersant.polaris/) · [Repository](https://github.com/agersant/polaris-android))
   - Polarios ([App Store](https://apps.apple.com/app/polarios/id1662366309) · [Repository](https://gitlab.com/elise/Polarios)) [third-party]
+  - Polarity ([Demo](https://www.hackster.io/hardcoder/polarity-a-music-player-for-polaris-8cd4eb) · [Repository](https://github.com/p-dial8891/Polarity)) [third-party]
 
 # Installation
 


### PR DESCRIPTION
I have been using polaris for some time now and think it is a great project. My impression was that it was of good quality and was a good use of the Rust ecosystem. Currently, I am working on a project to create a client with a terminal-style user interface that would be controlled with a joystick and 2 buttons. So far, it has been implemented on a raspberry pi zero SBC and is written in Rust.

My request is that links to it be added in your readme.

Thanks.