### PR TITLE
Adds a CLI option to display configured paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,21 @@ fn main() {
 
 	let paths = paths::Paths::new(&cli_options);
 
+	if cli_options.show_paths {
+		println!("Cache directory:  {:#?}", paths.cache_dir_path);
+		println!("Data directory:   {:#?}", paths.data_dir_path);
+		println!("Config file:      {:#?}", paths.config_file_path);
+		let log_file_path = match paths.log_file_path {
+			Some(log_file_path) => log_file_path,
+			None => "Undefined".into()
+		};
+		println!("Log file:         {:#?}", log_file_path);
+		#[cfg(unix)]
+		println!("Pid file:         {:#?}", paths.pid_file_path);
+		println!("Web directory:    {:#?}", paths.web_dir_path);
+		return;
+	}
+
 	// Logging
 	let log_level = cli_options.log_level.unwrap_or(LevelFilter::Info);
 	if let Err(e) = init_logging(log_level, &paths.log_file_path) {

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,6 +7,7 @@ use std::{
 
 pub struct CLIOptions {
 	pub show_help: bool,
+	pub show_paths: bool,
 	pub foreground: bool,
 	pub log_file_path: Option<PathBuf>,
 	#[cfg(unix)]
@@ -60,6 +61,7 @@ impl Manager {
 
 		Ok(CLIOptions {
 			show_help: matches.opt_present("h"),
+			show_paths: matches.opt_present("show-paths"),
 			#[cfg(unix)]
 			foreground: matches.opt_present("f"),
 			#[cfg(windows)]
@@ -86,6 +88,7 @@ fn get_options() -> getopts::Options {
 	let mut options = getopts::Options::new();
 
 	options.optflag("h", "help", "print this help menu");
+	options.optflag("", "show-paths", "print all configured paths and exit");
 
 	#[cfg(unix)]
 	options.optflag(


### PR DESCRIPTION
I know it's a very basic change/contribution. But it's quite interesting to know what options the binary has been compiled with, and I think it helps us packagers a lot.

Obviously, feel free to modify whatever you want or simply rewrite it completely.